### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,8 @@
 name: Docker CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/thulasirajkomminar/flightlog/security/code-scanning/2](https://github.com/thulasirajkomminar/flightlog/security/code-scanning/2)

In general, the problem is fixed by explicitly specifying `permissions` for the workflow or the individual job so that the `GITHUB_TOKEN` has only the scopes needed. For a CI workflow that only checks out code and runs Docker builds/validation, read access to repository contents is sufficient.

The single best fix here is to add a workflow-level `permissions` block (applies to all jobs) near the top of `.github/workflows/docker.yml`, specifying `contents: read`. This documents the intended least privilege and ensures the token remains restricted even if repository/org defaults change. No additional imports or methods are needed, since this is purely a YAML configuration change.

Concretely, in `.github/workflows/docker.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Docker CI` line and the `on:` block (around lines 1–3). No job-level overrides are needed because the job does not perform any write operations via the GitHub API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
