### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,6 @@
 name: Frontend CI
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,5 @@
 name: Frontend CI
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/thulasirajkomminar/flightlog/security/code-scanning/1](https://github.com/thulasirajkomminar/flightlog/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges required. For a pure CI workflow that only checks out code and runs local commands, `contents: read` is typically sufficient. You can set this at the workflow root (applies to all jobs) or directly under the `ci` job.

The best fix here, without changing functionality, is to add a root-level `permissions` section right after the `name:` line in `.github/workflows/frontend.yml`:

```yaml
name: Frontend CI
permissions:
  contents: read
```

This ensures that all jobs in this workflow, including `ci`, run with a token that can only read repository contents, which is enough for `actions/checkout` and does not interfere with any existing steps. No additional methods, imports, or definitions are required; this is purely a YAML configuration change within the given file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
